### PR TITLE
[electron] refs #1654 No extras during zip compression

### DIFF
--- a/electron/compress-standalone-release.sh
+++ b/electron/compress-standalone-release.sh
@@ -40,7 +40,7 @@ if [ -e "$WIN64_STL" ]; then
     fi
     echo "Zipping $WIN64_STL_ZIP"
     if [[ "$OSTYPE" == "linux"* ]]; then
-        zip -r --quiet "$WIN64_STL_ZIP" --owner=0 --group=0 "$WIN64_STL"
+        zip -r --quiet "$WIN64_STL_ZIP"  "$WIN64_STL"
     elif [[ "$OSTYPE" == "darwin"* ]]; then
         zip -r --quiet "$WIN64_STL_ZIP" "$WIN64_STL"
     elif [[ "$OSTYPE" == "msys"* ]]; then
@@ -57,7 +57,7 @@ if [ -e "$WIN32_STL" ]; then
     fi
     echo "Zipping $WIN32_STL_ZIP"
     if [[ "$OSTYPE" == "linux"* ]]; then
-        zip -r --quiet "$WIN32_STL_ZIP" --owner=0 --group=0 "$WIN32_STL"
+        zip -r --quiet "$WIN32_STL_ZIP" "$WIN32_STL"
     elif [[ "$OSTYPE" == "darwin"* ]]; then
         zip -r --quiet "$WIN32_STL_ZIP" "$WIN32_STL"
     elif [[ "$OSTYPE" == "msys"* ]]; then
@@ -74,7 +74,7 @@ if [ -e "$LNX64_STL" ]; then
     fi
     echo "Zipping $LNX64_STL_ZIP"
     if [[ "$OSTYPE" == "linux"* ]]; then
-        tar czf "$LNX64_STL_ZIP" --owner=0 --group=0 "$LNX64_STL"
+        tar czf "$LNX64_STL_ZIP"  "$LNX64_STL"
     elif [[ "$OSTYPE" == "darwin"* ]]; then
         tar czf "$LNX64_STL_ZIP"  "$LNX64_STL"
     fi

--- a/electron/compress-standalone-release.sh
+++ b/electron/compress-standalone-release.sh
@@ -41,6 +41,7 @@ if [ -e "$WIN64_STL" ]; then
     echo "Zipping $WIN64_STL_ZIP"
     if [[ "$OSTYPE" == "linux"* ]]; then
         zip -r --quiet "$WIN64_STL_ZIP"  "$WIN64_STL"
+        chown 0:0 "$WIN64_STL_ZIP"
     elif [[ "$OSTYPE" == "darwin"* ]]; then
         zip -r --quiet "$WIN64_STL_ZIP" "$WIN64_STL"
     elif [[ "$OSTYPE" == "msys"* ]]; then
@@ -57,7 +58,8 @@ if [ -e "$WIN32_STL" ]; then
     fi
     echo "Zipping $WIN32_STL_ZIP"
     if [[ "$OSTYPE" == "linux"* ]]; then
-        zip -r --quiet "$WIN32_STL_ZIP" "$WIN32_STL"
+        zip -r --quiet "$WIN32_STL_ZIP"  "$WIN32_STL"
+        chown 0:0 "$WIN32_STL_ZIP"
     elif [[ "$OSTYPE" == "darwin"* ]]; then
         zip -r --quiet "$WIN32_STL_ZIP" "$WIN32_STL"
     elif [[ "$OSTYPE" == "msys"* ]]; then
@@ -74,7 +76,7 @@ if [ -e "$LNX64_STL" ]; then
     fi
     echo "Zipping $LNX64_STL_ZIP"
     if [[ "$OSTYPE" == "linux"* ]]; then
-        tar czf "$LNX64_STL_ZIP"  "$LNX64_STL"
+        tar czf "$LNX64_STL_ZIP" --owner=0 --group=0 "$LNX64_STL"
     elif [[ "$OSTYPE" == "darwin"* ]]; then
         tar czf "$LNX64_STL_ZIP"  "$LNX64_STL"
     fi

--- a/electron/compress-standalone-release.sh
+++ b/electron/compress-standalone-release.sh
@@ -40,8 +40,7 @@ if [ -e "$WIN64_STL" ]; then
     fi
     echo "Zipping $WIN64_STL_ZIP"
     if [[ "$OSTYPE" == "linux"* ]]; then
-        zip -r --quiet "$WIN64_STL_ZIP"  "$WIN64_STL"
-        chown 0:0 "$WIN64_STL_ZIP"
+        zip -r --quiet -X "$WIN64_STL_ZIP"  "$WIN64_STL"
     elif [[ "$OSTYPE" == "darwin"* ]]; then
         zip -r --quiet "$WIN64_STL_ZIP" "$WIN64_STL"
     elif [[ "$OSTYPE" == "msys"* ]]; then
@@ -58,8 +57,7 @@ if [ -e "$WIN32_STL" ]; then
     fi
     echo "Zipping $WIN32_STL_ZIP"
     if [[ "$OSTYPE" == "linux"* ]]; then
-        zip -r --quiet "$WIN32_STL_ZIP"  "$WIN32_STL"
-        chown 0:0 "$WIN32_STL_ZIP"
+        zip -r --quiet -X "$WIN32_STL_ZIP"  "$WIN32_STL"
     elif [[ "$OSTYPE" == "darwin"* ]]; then
         zip -r --quiet "$WIN32_STL_ZIP" "$WIN32_STL"
     elif [[ "$OSTYPE" == "msys"* ]]; then


### PR DESCRIPTION
Fixes #1654

Changes:
- Fix broken invocation of `zip` command by using `-X` for a purpose similar to `--owner` arg of `tar` command.

Does this change need to mentioned in CHANGELOG.md?
No